### PR TITLE
Update:

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,9 +8,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "427f7363d4b6addafaae1a371d60da6eb0a236b6fb7884d5a087e47e92f55403",
-    strip_prefix = "rules_haskell-f929776456ee3814991c6dcc4d67d15088cb148e",
-    url = "https://github.com/tweag/rules_haskell/archive/f929776456ee3814991c6dcc4d67d15088cb148e.zip",
+    sha256 = "851e16edc7c33b977649d66f2f587071dde178a6e5bcfeca5fe9ebbe81924334",
+    strip_prefix = "rules_haskell-0.14",
+    url = "https://github.com/tweag/rules_haskell/archive/refs/tags/v0.14.tar.gz",
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -64,7 +64,7 @@ stack_snapshot(
 load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "haskell.compiler.ghc8104",
+    attribute_path = "haskell.compiler.ghc8107",
     compiler_flags = [
         "-Werror",
         "-Wall",
@@ -73,7 +73,7 @@ haskell_register_ghc_nixpkgs(
         "-Wredundant-constraints",
     ],
     repositories = {"nixpkgs": "@nixpkgs"},
-    version = "8.10.4",
+    version = "8.10.7",
 )
 
 ###############
@@ -82,10 +82,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
     ],
 )
 

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -10,12 +10,11 @@ local_repository(
 ##########################
 # rules_haskell preamble
 ##########################
-
 http_archive(
     name = "rules_haskell",
-    sha256 = "427f7363d4b6addafaae1a371d60da6eb0a236b6fb7884d5a087e47e92f55403",
-    strip_prefix = "rules_haskell-f929776456ee3814991c6dcc4d67d15088cb148e",
-    url = "https://github.com/tweag/rules_haskell/archive/f929776456ee3814991c6dcc4d67d15088cb148e.zip",
+    sha256 = "851e16edc7c33b977649d66f2f587071dde178a6e5bcfeca5fe9ebbe81924334",
+    strip_prefix = "rules_haskell-0.14",
+    url = "https://github.com/tweag/rules_haskell/archive/refs/tags/v0.14.tar.gz",
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -60,7 +59,7 @@ stack_snapshot(
 load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "haskell.compiler.ghc8104",
+    attribute_path = "haskell.compiler.ghc8107",
     compiler_flags = [
         "-Werror",
         "-Wall",
@@ -69,7 +68,7 @@ haskell_register_ghc_nixpkgs(
         "-Wredundant-constraints",
     ],
     repositories = {"nixpkgs": "@nixpkgs"},
-    version = "8.10.4",
+    version = "8.10.7",
 )
 
 ###############
@@ -78,10 +77,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
     ],
 )
 

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,1 +1,1 @@
-import (fetchTarball "https://github.com/nixos/nixpkgs/archive/46113713d4f25579e07b78116a61ab6f178f4153.tar.gz")
+import (fetchTarball "https://github.com/nixos/nixpkgs/archive/89f196fe781c53cb50fef61d3063fa5e8d61b6e5.tar.gz")

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ mkShell {
     binutils
     cacert
     nix
+    git
     openjdk11
     python3
     # convenience dependencies

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -13,9 +13,9 @@ local_repository(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "427f7363d4b6addafaae1a371d60da6eb0a236b6fb7884d5a087e47e92f55403",
-    strip_prefix = "rules_haskell-f929776456ee3814991c6dcc4d67d15088cb148e",
-    url = "https://github.com/tweag/rules_haskell/archive/f929776456ee3814991c6dcc4d67d15088cb148e.zip",
+    sha256 = "851e16edc7c33b977649d66f2f587071dde178a6e5bcfeca5fe9ebbe81924334",
+    strip_prefix = "rules_haskell-0.14",
+    url = "https://github.com/tweag/rules_haskell/archive/refs/tags/v0.14.tar.gz",
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -83,10 +83,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
     ],
 )
 


### PR DESCRIPTION
- nixpkgs so now it is using bazel 4.2.1:
https://lazamar.co.uk/nix-versions/?channel=nixos-unstable&package=bazel
- rules_haskell to latest release
- rules_go to 0.30.0
- ghc to 8.10.7