### PR TITLE
Replace custom parsing with GetOpt

### DIFF
--- a/cabalscan/exe/Main.hs
+++ b/cabalscan/exe/Main.hs
@@ -10,8 +10,8 @@ import qualified Data.ByteString.Lazy.Char8 as ByteString.Lazy
 
 main :: IO ()
 main = do
-  opts <- Options.parseCommandLine
-  mapM generateRulesForCabalFile (Options.cabalFiles opts)
+  cabalFiles <- Options.parseCommandLine
+  mapM generateRulesForCabalFile cabalFiles
     >>= printRuleInfos . concat
 
 printRuleInfos :: [RuleInfo] -> IO ()

--- a/cabalscan/src/CabalScan/Options.hs
+++ b/cabalscan/src/CabalScan/Options.hs
@@ -5,44 +5,34 @@ module CabalScan.Options
   , parseCommandLine
   ) where
 
-import Data.List (intercalate)
 import Path (Abs, File, Path, parseAbsFile)
 import System.Environment
-import System.Exit
+import System.Console.GetOpt
+import System.Exit (exitFailure, exitSuccess)
+import Data.List (intercalate)
 import System.IO (hPutStrLn, stderr, stdout, Handle)
+
+data InputOptions = Help
+
+options :: [ OptDescr InputOptions ]
+options = [ Option ['h'] ["help"] (NoArg Help) "Prints this message" ]
 
 data Options = Options
   { cabalFiles :: [Path Abs File]
   }
 
-data InvocationError = MissingFiles | WrongFilePath String | PrintHelp
+parseArgs :: [String] -> IO [Path Abs File]
+parseArgs argv = case getOpt Permute options argv of
+                     (_:_,_,_)   -> hPutLn stdout [usage] *> exitSuccess
+                     (_,[],_)    -> hPutLn stderr [missingFiles, usage] *> exitFailure
+                     (_,files,_) -> sequence [ maybe (logErrAndExit f) return (parseAbsFile f) | f <- files ]
+  where usage = [usageInfo header options]
+        header = "Usage: cabalscan [OPTION...] CABAL_FILES..."
+        missingFiles = ["Missing: CABAL_FILES..."]
+        wrongpath f = ["Couldn't parse absolute file path: " ++ f]
+        logErrAndExit f = hPutLn stderr [wrongpath f, usage] *> exitFailure
+        hPutLn :: Handle -> [[String]] -> IO ()
+        hPutLn h = hPutStrLn h . intercalate "\n" . map unlines
 
 parseCommandLine :: IO Options
-parseCommandLine = do
-  args <- getArgs
-  case parseArgs args of
-    Right xs -> return (Options {cabalFiles = xs})
-    Left err -> printMsgAndExit err
-
-parseArgs :: [String] -> Either InvocationError [Path Abs File]
-parseArgs [] = Left MissingFiles
-parseArgs xs
-  | any (`elem` ["-h", "--help"]) xs = Left PrintHelp
-  | otherwise =
-    sequence [ maybe (Left $ WrongFilePath x) Right (parseAbsFile x) | x <- xs ]
-
-printMsgAndExit :: InvocationError -> IO a
-printMsgAndExit = \case
-  PrintHelp       -> hPutLn stdout [info, usage, options] *> exitSuccess
-  MissingFiles    -> hPutLn stderr [missing, usage]       *> exitFailure
-  WrongFilePath f -> hPutLn stderr [wrongpath f, usage]   *> exitFailure
-  where
-    info = ["cabalscan - extract build information from Cabal files"]
-    usage = ["Usage: cabalscan CABAL_FILES...",
-             "  Prints in stdout information extracted from Cabal files in JSON format."]
-    options = ["Available options:",
-               "-h,--help                Show this help text"]
-    missing = ["Missing: CABAL_FILES..."]
-    wrongpath p = ["Couldn't parse absolute file path: " ++ p]
-    hPutLn :: Handle -> [[String]] -> IO ()
-    hPutLn h = hPutStrLn h . intercalate "\n" . map unlines
+parseCommandLine = getArgs >>= parseArgs >>= return . Options


### PR DESCRIPTION
Replacing custom parsing in favor of GetOpt. I think it improves the situation (less code).

Usage examples:
1. File doesn't exist.
```bash
$ bazel run //cabalscan:cabalscan -- asdfds
Couldn't parse absolute file path: 'asdfds'

Usage: cabalscan [OPTION...] CABAL_FILES...
  Prints in stdout information extracted from Cabal files in JSON format.

  -h  --help  Prints this message

```

2. Help msg
```bash
$ bazel run //cabalscan:cabalscan -- asdfds -h
Usage: cabalscan [OPTION...] CABAL_FILES...
  Prints in stdout information extracted from Cabal files in JSON format.

  -h  --help  Prints this message

```

3. Missing cabal files
```bash
$ bazel run //cabalscan:cabalscan --
Missing: CABAL_FILES...

Usage: cabalscan [OPTION...] CABAL_FILES...
  Prints in stdout information extracted from Cabal files in JSON format.

  -h  --help  Prints this message

```