### PR TITLE
Use gazelle:resolve to resolve extra libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ rule need to be written by the user.
 ## Directives
 
 ```python
-# gazelle:cabal_extra_libraries sodium=@libsodium//:libsodium
+# gazelle:resolve gazelle_cabal sodium @libsodium//:libsodium
 ```
 Maps names in the Cabal file's `extra-libraries` field to Bazel
 labels. The labels are added to the `deps` attribute of the

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,7 +79,6 @@ haskell_register_ghc_nixpkgs(
 # Go preamble
 ###############
 
-
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,12 +79,13 @@ haskell_register_ghc_nixpkgs(
 # Go preamble
 ###############
 
+
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
+    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
     ],
 )
 
@@ -105,10 +106,10 @@ go_rules_dependencies()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+    sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -113,7 +113,15 @@ http_archive(
     ],
 )
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+# go_repository added due to: https://github.com/bazelbuild/bazel-gazelle/issues/1217
+go_repository(
+    name = "org_golang_x_xerrors",
+    importpath = "golang.org/x/xerrors",
+    sum = "h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=",
+    version = "v0.0.0-20200804184101-5ec99f83aff1",
+)
 
 gazelle_dependencies()
 

--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -6,7 +6,7 @@ load(
 )
 load("@rules_haskell//haskell:defs.bzl", "ghc_plugin")
 
-# gazelle:cabal_extra_libraries z=@zlib.dev//:zlib
+# gazelle:resolve gazelle_cabal z @zlib.dev//:zlib
 gazelle(
     name = "gazelle",
     gazelle = ":gazelle_binary",

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -116,6 +116,7 @@ go_repository(
     sum = "h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=",
     version = "v0.0.0-20200804184101-5ec99f83aff1",
 )
+
 gazelle_dependencies()
 
 ####################

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -76,10 +76,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
+    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
     ],
 )
 
@@ -100,15 +100,22 @@ go_rules_dependencies()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+    sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
     ],
 )
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
+# go_repository added due to: https://github.com/bazelbuild/bazel-gazelle/issues/1217
+go_repository(
+    name = "org_golang_x_xerrors",
+    importpath = "golang.org/x/xerrors",
+    sum = "h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=",
+    version = "v0.0.0-20200804184101-5ec99f83aff1",
+)
 gazelle_dependencies()
 
 ####################

--- a/gazelle_cabal/dependency_resolution.go
+++ b/gazelle_cabal/dependency_resolution.go
@@ -70,8 +70,7 @@ func setCompilerFlagsAttribute(
 	ghcOpts := make([]string, 0, ghcOptsSize)
 
 	dropToolMacroDefs(importData.GhcOpts, importData.Tools, &ghcOpts)
-	addLibraryFlags(unresolvedExtraLibraries, &compilerFlags)
-	// addLibraryFlags(extraLibrariesMap, importData.ExtraLibraries, &ghcOpts)
+	addLibraryFlags(unresolvedExtraLibraries, &ghcOpts)
 	addMacroDefs(ix, toolRepo, importData.Tools, from, &ghcOpts)
 	SetAttrIfNotEmpty(r, "ghcopts", ghcOpts)
 }

--- a/gazelle_cabal/dependency_resolution_test.go
+++ b/gazelle_cabal/dependency_resolution_test.go
@@ -83,28 +83,17 @@ func TestToolMacroName(t *testing.T) {
 
 func TestAddLibraryFlags(t *testing.T) {
 
-	libraryMap := map[string]string{"z": "@zlib.dev//:zlib"}
-	libraries := []string{"m", "z", "SDL"}
+	libraries := []string{"m", "SDL"}
 	got := make([]string, 0, len(libraries))
-	addLibraryFlags(libraryMap, libraries, &got)
+	addLibraryFlags(libraries, &got)
 	wanted := []string{"-lm", "-lSDL"}
 	if !reflect.DeepEqual(got, wanted) {
 		t.Errorf("got %v, wanted %v", got, wanted)
 	}
 
-	libraryMap = map[string]string{"z": "@zlib.dev//:zlib"}
-	libraries = []string{"m", "SDL"}
-	got = make([]string, 0, len(libraries))
-	addLibraryFlags(libraryMap, libraries, &got)
-	wanted = []string{"-lm", "-lSDL"}
-	if !reflect.DeepEqual(got, wanted) {
-		t.Errorf("got %v, wanted %v", got, wanted)
-	}
-
-	libraryMap = map[string]string{}
 	libraries = []string{}
 	got = make([]string, 0, len(libraries))
-	addLibraryFlags(libraryMap, libraries, &got)
+	addLibraryFlags(libraries, &got)
 	wanted = []string{}
 	if !reflect.DeepEqual(got, wanted) {
 		t.Errorf("got %v, wanted %v", got, wanted)

--- a/gazelle_cabal/lang.go
+++ b/gazelle_cabal/lang.go
@@ -4,6 +4,7 @@ package gazelle_cabal
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"path"
 	"path/filepath"
@@ -41,6 +42,9 @@ func (*gazelleCabalLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error { 
 func (*gazelleCabalLang) KnownDirectives() []string {
 	return []string{
 		"cabal_haskell_package_repo",
+		// Added to avoid warnings when running :gazelle-update-repos
+		// https://github.com/tweag/gazelle_cabal/issues/8
+		"resolve",
 	}
 }
 

--- a/gazelle_cabal/lang.go
+++ b/gazelle_cabal/lang.go
@@ -4,7 +4,6 @@ package gazelle_cabal
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 	"path"
 	"path/filepath"
@@ -19,7 +18,6 @@ import (
 
 	"os"
 	"os/exec"
-	"strings"
 )
 
 ////////////////////////////////////////////////////
@@ -42,13 +40,11 @@ func (*gazelleCabalLang) CheckFlags(fs *flag.FlagSet, c *config.Config) error { 
 
 func (*gazelleCabalLang) KnownDirectives() []string {
 	return []string{
-		"cabal_extra_libraries",
 		"cabal_haskell_package_repo",
 	}
 }
 
 type Config struct {
-	ExtraLibrariesMap  map[string]string
 	HaskellPackageRepo string
 }
 
@@ -63,30 +59,17 @@ func (*gazelleCabalLang) Configure(c *config.Config, rel string, f *rule.File) {
 		extraConfig = m.(Config)
 	} else {
 		extraConfig = Config{
-			ExtraLibrariesMap:  make(map[string]string),
 			HaskellPackageRepo: "stackage",
 		}
 	}
 
 	for _, directive := range f.Directives {
 		switch directive.Key {
-		case "cabal_extra_libraries":
-			parseExtraLibraries(&extraConfig, directive.Value)
 		case "cabal_haskell_package_repo":
 			extraConfig.HaskellPackageRepo = directive.Value
 		}
 	}
 	c.Exts[gazelleCabalName] = extraConfig
-}
-
-func parseExtraLibraries(config *Config, value string) {
-	kv := strings.Split(value, "=")
-	if len(kv) != 2 {
-		msg := "Can't parse value of cabal_extra_libraries: %s"
-		err := fmt.Errorf(msg, value)
-		log.Fatal(err)
-	}
-	(*config).ExtraLibrariesMap[kv[0]] = kv[1]
 }
 
 var haskellAttrInfo = rule.KindInfo{
@@ -158,12 +141,13 @@ func (*gazelleCabalLang) Imports(c *config.Config, r *rule.Rule, f *rule.File) [
 func (*gazelleCabalLang) Embeds(r *rule.Rule, from label.Label) []label.Label { return nil }
 
 func (*gazelleCabalLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
-	extraLibrariesMap := c.Exts[gazelleCabalName].(Config).ExtraLibrariesMap
 	packageRepo := c.Exts[gazelleCabalName].(Config).HaskellPackageRepo
 	toolRepo := packageRepo + "-exe"
 	importData := imports.(ImportData)
-	setDepsAndPluginsAttributes(extraLibrariesMap, packageRepo, ix, r, importData, from)
-	setCompilerFlagsAttribute(extraLibrariesMap, toolRepo, ix, r, importData, from)
+
+	libraryLabels, unresolvedExtraLibraries := getExtraLibraryLabels(c, importData.ExtraLibraries)
+	setDepsAndPluginsAttributes(libraryLabels, packageRepo, ix, r, importData, from)
+	setCompilerFlagsAttribute(unresolvedExtraLibraries, toolRepo, ix, r, importData, from)
 	setToolsAttribute(ix, toolRepo, r, importData, from)
 }
 

--- a/tests/alternative-deps/BUILD.bazel
+++ b/tests/alternative-deps/BUILD.bazel
@@ -6,7 +6,7 @@ load(
 )
 load("@rules_haskell//haskell:defs.bzl", "ghc_plugin")
 
-# gazelle:cabal_extra_libraries z=@zlib.dev//:zlib
+# gazelle:resolve gazelle_cabal z @zlib.dev//:zlib
 # gazelle:cabal_haskell_package_repo stackage-b
 gazelle(
     name = "gazelle",

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -52,10 +52,22 @@ gazelle_cabal_dependencies(
 
 stack_snapshot(
     name = "stackage-b",
+    components = {
+        "tasty-discover": [
+            "lib",
+            "exe:tasty-discover",
+        ],
+    },
     packages = [
         "aeson",  # keep
+        "base",
+        "inspection-testing",
         "path",  # keep
         "path-io",  #keep
+        "tasty",
+        "tasty-discover",
+        "tasty-hunit",
+        "void",
     ],
     snapshot = "lts-18.1",
 )
@@ -81,10 +93,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
+    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
     ],
 )
 
@@ -105,14 +117,22 @@ go_rules_dependencies()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+    sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
     ],
 )
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+# go_repository added due to: https://github.com/bazelbuild/bazel-gazelle/issues/1217
+go_repository(
+    name = "org_golang_x_xerrors",
+    importpath = "golang.org/x/xerrors",
+    sum = "h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=",
+    version = "v0.0.0-20200804184101-5ec99f83aff1",
+)
 
 gazelle_dependencies()
 

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -52,22 +52,11 @@ gazelle_cabal_dependencies(
 
 stack_snapshot(
     name = "stackage-b",
-    components = {
-        "tasty-discover": [
-            "lib",
-            "exe:tasty-discover",
-        ],
-    },
     packages = [
         "aeson",  # keep
-        "base",
         "inspection-testing",
         "path",  # keep
         "path-io",  #keep
-        "tasty",
-        "tasty-discover",
-        "tasty-hunit",
-        "void",
     ],
     snapshot = "lts-18.1",
 )


### PR DESCRIPTION
This PR should fix https://github.com/tweag/gazelle_cabal/issues/8

Issues encountered:
- explicitly adding `resolve` to known directives in order to avoid warnings when running [`gazelle-update-repos`](https://github.com/tweag/gazelle_cabal/issues/8#issue-1058766051)
Indeed [this code](https://github.com/bazelbuild/bazel-gazelle/blob/5b8616dbb7dad825c61ffbb12ea9f75622568657/walk/walk.go#L277) doesn't contain `resolve` directive on the list of known directives (checked with `fmt.Printf` and `override_repository`): 
```
gazelle: known directives: map[build_file_name:%!s(bool=true) build_tags:%!s(bool=true) cabal_haskell_package_repo:%!s(bool=true) exclude:%!s(bool=true) follow:%!s(bool=true) go_generate_proto:%!s(bool=true) go_grpc_compilers:%!s(bool=true) go_naming_convention:%!s(bool=true) go_naming_convention_external:%!s(bool=true) go_proto_compilers:%!s(bool=true) go_visibility:%!s(bool=true) ignore:%!s(bool=true) importmap_prefix:%!s(bool=true) lang:%!s(bool=true) map_kind:%!s(bool=true) prefix:%!s(bool=true) proto:%!s(bool=true) proto_group:%!s(bool=true) proto_import_prefix:%!s(bool=true) proto_strip_import_prefix:%!s(bool=true)]
```
- explicitly adding dependency on `golang.org/x/xerrors` due to this gazelle issue: https://github.com/bazelbuild/bazel-gazelle/issues/1217