### PR TITLE
Use Filepath and Directory packages

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,7 @@
+common:ghc_8_10_7 --repo_env=GHC_VERSION=8.10.7
+
+common:ghc_9_0_2 --repo_env=GHC_VERSION=9.0.2
+
+common:ghc_9_2_2 --repo_env=GHC_VERSION=9.2.2
+
 try-import .bazelrc.local

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        ghc-version: [ghc_8_10_7, ghc_9_0_2, ghc_9_2_2]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -39,15 +40,15 @@ jobs:
           ln -s ../.bazelrc.local example/.bazelrc.local
           ln -s ../../.bazelrc.local tests/alternative-deps/.bazelrc.local
       - name: Build & test
-        run: nix-shell --pure --run 'bazel test --test_output=all //...'
+        run: nix-shell --pure --run 'bazel test --config=${{ matrix.ghc-version }} --test_output=all //...'
       - name: Test the example
         run: |
           cd example
-          nix-shell --pure --run 'bazel run //:gazelle'
+          nix-shell --pure --run 'bazel run //:gazelle --config=${{ matrix.ghc-version }}'
           # Gazelle doesn't remove rules by default
           grep -q another-haskell-binary package-a/BUILD.bazel
-          nix-shell --pure --run 'bazel run //:gazelle -- fix -mode diff' || true
-          nix-shell --pure --run 'bazel run //:gazelle -- fix'
+          nix-shell --pure --run 'bazel run //:gazelle --config=${{ matrix.ghc-version }} -- fix -mode diff' || true
+          nix-shell --pure --run 'bazel run //:gazelle --config=${{ matrix.ghc-version }} -- fix'
           # Test that fix kept and removed the expected rules
           echo "! grep -q another-haskell-binary package-a/BUILD.bazel"
           bash -c "! grep -q another-haskell-binary package-a/BUILD.bazel"
@@ -93,13 +94,13 @@ jobs:
           bash -cx "grep -q \":mtl\" package-b/BUILD.bazel"
           bash -cx "grep -q \"//package-c:mtl\" package-b/BUILD.bazel"
           # Test gazelle-update-repos
-          nix-shell --pure --run 'bazel run //:gazelle-update-repos'
-          nix-shell --pure --run 'bazel test //...'
+          nix-shell --pure --run 'bazel run //:gazelle-update-repos --config=${{ matrix.ghc-version }}'
+          nix-shell --pure --run 'bazel test //... --config=${{ matrix.ghc-version }}'
       - name: Test alternative dependencies
         run: |
           cd tests/alternative-deps
-          nix-shell --pure --run 'bazel run //:gazelle'
-          nix-shell --pure --run 'bazel run //:gazelle-update-repos'
-          nix-shell --pure --run 'bazel test //...'
+          nix-shell --pure --run 'bazel run //:gazelle --config=${{ matrix.ghc-version }}'
+          nix-shell --pure --run 'bazel run //:gazelle-update-repos --config=${{ matrix.ghc-version }}'
+          nix-shell --pure --run 'bazel test //... --config=${{ matrix.ghc-version }}'
       - name: Test for buildifier suggestions
         run: nix-shell --pure --run 'bazel run //:buildifier-diff'

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,43 +53,29 @@ stack_snapshot(
                 "lib",
                 "exe:tasty-discover",
             ],
-        } if ghc_version == "8.10.7" else {
-            "tasty-discover": [
-                "lib",
-                "exe:tasty-discover",
-            ],
-            "attoparsec": [
-                "lib",
-                "lib:attoparsec-internal",
-            ],
-        },
-    components_dependencies =
-        None if ghc_version == "8.10.7" else {
-            "attoparsec": """{"lib:attoparsec": ["lib:attoparsec-internal"]}""",
         },
     local_snapshot = "//:snapshot-" + ghc_version + ".yaml",
     packages = [
         "Cabal",
+        "directory",
+        "filepath",
         "hspec",
         "json",
-        "path",
-        "path-io",
         "tasty",
         "tasty-discover",
         "tasty-hspec",
+        "temporary",
     ],
     setup_deps = {
-        "transformers-compat": ["@stackage//:Cabal"],
-        "hspec-discover": ["@stackage//:Cabal"],
         "call-stack": ["@stackage//:Cabal"],
-        "HUnit": ["@stackage//:Cabal"],
-        "quickcheck": ["@stackage//:Cabal"],
+        "hspec": ["@stackage//:Cabal"],
+        "hspec-core": ["@stackage//:Cabal"],
+        "hspec-discover": ["@stackage//:Cabal"],
         "hspec-expectations": ["@stackage//:Cabal"],
+        "HUnit": ["@stackage//:Cabal"],
         "quickcheck-io": ["@stackage//:Cabal"],
         "tasty-discover": ["@stackage//:Cabal"],
-        "hspec-core": ["@stackage//:Cabal"],
-        "bifunctors": ["@stackage//:Cabal"],
-        "hspec": ["@stackage//:Cabal"],
+        "transformers-compat": ["@stackage//:Cabal"],
     },
 )
 

--- a/cabalscan/BUILD.bazel
+++ b/cabalscan/BUILD.bazel
@@ -16,6 +16,8 @@ haskell_toolchain_library(name = "Cabal")
 
 haskell_toolchain_library(name = "containers")
 
+haskell_toolchain_library(name = "directory")
+
 haskell_toolchain_library(name = "filepath")
 
 haskell_library(
@@ -29,10 +31,9 @@ haskell_library(
         ":Cabal",
         ":base",
         ":containers",
+        ":directory",
         ":filepath",
         "@io_tweag_gazelle_cabal_deps//:json",
-        "@io_tweag_gazelle_cabal_deps//:path",
-        "@io_tweag_gazelle_cabal_deps//:path-io",
     ],
 )
 
@@ -66,10 +67,11 @@ haskell_test(
     deps = [
         ":base",
         ":cabalscan-library",
+        ":directory",
+        ":filepath",
         "@stackage//:hspec",
-        "@stackage//:path",
-        "@stackage//:path-io",
         "@stackage//:tasty",
         "@stackage//:tasty-hspec",
+        "@stackage//:temporary",
     ],
 )

--- a/cabalscan/src/Cabal/Cabal_8_10.hs
+++ b/cabalscan/src/Cabal/Cabal_8_10.hs
@@ -1,0 +1,34 @@
+{-#LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ == 810
+
+module Cabal.Cabal_8_10(module Cabal)
+
+where
+
+import Distribution.Compiler as Cabal (CompilerFlavor(GHC), perCompilerFlavorToList, unknownCompilerInfo, CompilerId(CompilerId), AbiTag(NoAbiTag))
+import Distribution.ModuleName as Cabal (toFilePath, components)
+import Distribution.Package as Cabal ()
+import Distribution.PackageDescription as Cabal (allLibraries, executables, testSuites, benchmarks, package, dataFiles, Library, libName, exposedModules, libBuildInfo, LibraryName(LSubLibName), Executable, exeName, buildInfo, hsSourceDirs, modulePath, TestSuite, testName, testBuildInfo, TestSuiteInterface(TestSuiteExeV10), testInterface, Benchmark, benchmarkName, benchmarkBuildInfo, BenchmarkInterface(BenchmarkExeV10), benchmarkInterface, BuildInfo, buildable, otherModules, extraLibs)
+import Distribution.PackageDescription.Configuration as Cabal (finalizePD)
+import Distribution.PackageDescription.Parsec as Cabal (readGenericPackageDescription)
+import Distribution.Types.BuildInfo as Cabal (buildToolDepends, targetBuildDepends, defaultExtensions, cppOptions, ldOptions, options)
+import Distribution.Types.ComponentRequestedSpec as Cabal (ComponentRequestedSpec(ComponentRequestedSpec), testsRequested, benchmarksRequested)
+import Distribution.Types.Dependency as Cabal (Dependency, depLibraries, depPkgName)
+import Distribution.Types.ExeDependency as Cabal (ExeDependency(ExeDependency))
+import Distribution.Types.Library as Cabal (libVisibility)
+import Distribution.Types.LibraryVisibility as Cabal (LibraryVisibility(LibraryVisibilityPrivate))
+import Distribution.Types.PackageDescription as Cabal (PackageDescription)
+import Distribution.Types.PackageId as Cabal (PackageIdentifier, pkgName, pkgVersion)
+import Distribution.Types.PackageName as Cabal (PackageName, unPackageName)
+import Distribution.Types.UnqualComponentName as Cabal (unUnqualComponentName)
+import Distribution.Types.Version as Cabal (mkVersion)
+import Distribution.Pretty as Cabal (prettyShow)
+import Distribution.System as Cabal (Platform(Platform), buildArch, buildOS)
+import Distribution.Verbosity as Cabal (silent)
+
+#else
+
+module Cabal.Cabal_8_10 where
+
+#endif

--- a/cabalscan/src/Cabal/Cabal_9_0.hs
+++ b/cabalscan/src/Cabal/Cabal_9_0.hs
@@ -1,0 +1,42 @@
+{-#LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ == 900
+
+module Cabal.Cabal_9_0(module Cabal, depLibraries)
+
+where
+
+import Distribution.Compiler as Cabal (CompilerFlavor(GHC), perCompilerFlavorToList, unknownCompilerInfo, CompilerId(CompilerId), AbiTag(NoAbiTag))
+import Distribution.ModuleName as Cabal (toFilePath, components)
+import Distribution.Package as Cabal ()
+import Distribution.PackageDescription as Cabal (allLibraries, executables, testSuites, benchmarks, package, dataFiles, Library, libName, exposedModules, libBuildInfo, Executable, exeName, buildInfo, hsSourceDirs, modulePath, TestSuite, testName, testBuildInfo, TestSuiteInterface(TestSuiteExeV10), testInterface, Benchmark, benchmarkName, benchmarkBuildInfo, BenchmarkInterface(BenchmarkExeV10), benchmarkInterface, BuildInfo, buildable, otherModules, extraLibs)
+import Distribution.PackageDescription.Configuration as Cabal (finalizePD)
+import Distribution.PackageDescription.Parsec as Cabal (readGenericPackageDescription)
+import Distribution.Types.BuildInfo as Cabal (buildToolDepends, targetBuildDepends, defaultExtensions, cppOptions, ldOptions, options)
+import Distribution.Types.ComponentRequestedSpec as Cabal (ComponentRequestedSpec(ComponentRequestedSpec), testsRequested, benchmarksRequested)
+import Distribution.Types.Dependency as Cabal (Dependency, depPkgName)
+import Distribution.Types.ExeDependency as Cabal (ExeDependency(ExeDependency))
+import Distribution.Types.Library as Cabal (libVisibility)
+import Distribution.Types.LibraryName as Cabal (LibraryName(LSubLibName))
+import Distribution.Types.LibraryVisibility as Cabal (LibraryVisibility(LibraryVisibilityPrivate))
+import Distribution.Types.PackageDescription as Cabal (PackageDescription)
+import Distribution.Types.PackageId as Cabal (PackageIdentifier, pkgName, pkgVersion)
+import Distribution.Types.PackageName as Cabal (PackageName, unPackageName)
+import Distribution.Types.UnqualComponentName as Cabal (unUnqualComponentName)
+import Distribution.Types.Version as Cabal (mkVersion)
+import Distribution.Pretty as Cabal (prettyShow)
+import Distribution.System as Cabal (Platform(Platform), buildArch, buildOS)
+import Distribution.Verbosity as Cabal (silent)
+
+import qualified Distribution.Types.Dependency as C (depLibraries)
+import qualified Distribution.Compat.NonEmptySet as C (toSet)
+import Data.Set.Internal (Set)
+
+depLibraries :: Cabal.Dependency -> Set Cabal.LibraryName
+depLibraries = C.toSet . C.depLibraries
+
+#else
+
+module Cabal.Cabal_9_0 where
+
+#endif

--- a/cabalscan/src/Cabal/Cabal_9_2.hs
+++ b/cabalscan/src/Cabal/Cabal_9_2.hs
@@ -1,0 +1,47 @@
+{-#LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ == 902
+
+module Cabal.Cabal_9_2(module Cabal, depLibraries, hsSourceDirs)
+
+where
+
+import Distribution.Compiler as Cabal (CompilerFlavor(GHC), perCompilerFlavorToList, unknownCompilerInfo, CompilerId(CompilerId), AbiTag(NoAbiTag))
+import Distribution.ModuleName as Cabal (toFilePath, components)
+import Distribution.Package as Cabal ()
+import Distribution.PackageDescription as Cabal (allLibraries, executables, testSuites, benchmarks, package, dataFiles, Library, libName, exposedModules, libBuildInfo, Executable, exeName, buildInfo, modulePath, TestSuite, testName, testBuildInfo, TestSuiteInterface(TestSuiteExeV10), testInterface, Benchmark, benchmarkName, benchmarkBuildInfo, BenchmarkInterface(BenchmarkExeV10), benchmarkInterface, BuildInfo, buildable, otherModules, extraLibs)
+import Distribution.PackageDescription.Configuration as Cabal (finalizePD)
+import Distribution.PackageDescription.Parsec as Cabal (readGenericPackageDescription)
+import Distribution.Types.BuildInfo as Cabal (buildToolDepends, targetBuildDepends, defaultExtensions, cppOptions, ldOptions, options)
+import Distribution.Types.ComponentRequestedSpec as Cabal (ComponentRequestedSpec(ComponentRequestedSpec), testsRequested, benchmarksRequested)
+import Distribution.Types.Dependency as Cabal (Dependency, depPkgName)
+import Distribution.Types.ExeDependency as Cabal (ExeDependency(ExeDependency))
+import Distribution.Types.Library as Cabal (libVisibility)
+import Distribution.Types.LibraryName as Cabal (LibraryName(LSubLibName))
+import Distribution.Types.LibraryVisibility as Cabal (LibraryVisibility(LibraryVisibilityPrivate))
+import Distribution.Types.PackageDescription as Cabal (PackageDescription)
+import Distribution.Types.PackageId as Cabal (PackageIdentifier, pkgName, pkgVersion)
+import Distribution.Types.PackageName as Cabal (PackageName, unPackageName)
+import Distribution.Types.UnqualComponentName as Cabal (unUnqualComponentName)
+import Distribution.Types.Version as Cabal (mkVersion)
+import Distribution.Pretty as Cabal (prettyShow)
+import Distribution.System as Cabal (Platform(Platform), buildArch, buildOS)
+import Distribution.Verbosity as Cabal (silent)
+
+import qualified Distribution.Types.Dependency as C (depLibraries)
+import qualified Distribution.Compat.NonEmptySet as C (toSet)
+import Data.Set.Internal (Set)
+import qualified Distribution.PackageDescription as C (hsSourceDirs)
+import qualified Distribution.Utils.Path as C (getSymbolicPath)
+
+depLibraries :: Cabal.Dependency -> Set Cabal.LibraryName
+depLibraries = C.toSet . C.depLibraries
+
+hsSourceDirs :: Cabal.BuildInfo -> [FilePath]
+hsSourceDirs = map C.getSymbolicPath . C.hsSourceDirs
+
+#else
+
+module Cabal.Cabal_9_2 where
+
+#endif

--- a/cabalscan/src/CabalScan/Options.hs
+++ b/cabalscan/src/CabalScan/Options.hs
@@ -3,14 +3,13 @@ module CabalScan.Options (parseCommandLine) where
 import System.Environment
 import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty((:|)))
-import qualified Path as Path
 import qualified System.IO as SIO
 import qualified System.Exit as Exit
 import qualified System.Console.GetOpt as Opt
 
 data InputOptions = Help
 
-type CabalFile = Path.Path Path.Abs Path.File
+type CabalFile = FilePath
 type CabalFiles = NonEmpty CabalFile
 
 options :: [ Opt.OptDescr InputOptions ]
@@ -20,7 +19,7 @@ parseArgs :: [String] -> IO CabalFiles
 parseArgs argv = case Opt.getOpt Opt.Permute options argv of
                      (_:_,_,_) -> hPutLn SIO.stdout [usage] *> Exit.exitSuccess
                      (_,[],_)  -> hPutLn SIO.stderr [missingFiles, usage] *> Exit.exitFailure
-                     (_,h:t,_) -> traverse validate (h:|t)
+                     (_,h:t,_) -> return (h:|t)
   where usage :: String
         usage = Opt.usageInfo header options
         header :: String
@@ -28,12 +27,6 @@ parseArgs argv = case Opt.getOpt Opt.Permute options argv of
                           "  Prints in stdout information extracted from Cabal files in JSON format."]
         missingFiles :: String
         missingFiles = "Missing: CABAL_FILES..."
-        wrongpath :: FilePath -> String
-        wrongpath f = "Couldn't parse absolute file path: '" ++ f ++ "'"
-        logErrAndExit :: FilePath -> IO a
-        logErrAndExit f = hPutLn SIO.stderr [wrongpath f, usage] *> Exit.exitFailure
-        validate :: FilePath -> IO CabalFile
-        validate path = maybe (logErrAndExit path) return (Path.parseAbsFile path)
         hPutLn :: SIO.Handle -> [String] -> IO ()
         hPutLn h = SIO.hPutStrLn h . intercalate "\n\n"
 

--- a/cabalscan/src/CabalScan/RuleGenerator.hs
+++ b/cabalscan/src/CabalScan/RuleGenerator.hs
@@ -18,25 +18,25 @@ import Data.List (intersperse)
 import Data.List.NonEmpty (nonEmpty)
 import Data.Maybe (catMaybes, listToMaybe)
 import Data.Set.Internal as Set (toList)
-import qualified Distribution.Compiler as Cabal
-import qualified Distribution.ModuleName as Cabal
-import qualified Distribution.Package as Cabal
-import qualified Distribution.PackageDescription as Cabal
-import qualified Distribution.PackageDescription.Configuration as Cabal
-import qualified Distribution.PackageDescription.Parsec as Cabal
-import qualified Distribution.Types.ComponentRequestedSpec as Cabal
-import qualified Distribution.Types.ExeDependency as Cabal
-import qualified Distribution.Types.LibraryVisibility as Cabal
-import qualified Distribution.Types.UnqualComponentName as Cabal
-import qualified Distribution.Types.Version as Cabal
-import qualified Distribution.Pretty as Cabal
-import qualified Distribution.System as Cabal
-import qualified Distribution.Verbosity as Verbosity
 import Path (Path, Rel, Dir, File)
 import qualified Path as Path
 import qualified Path.IO as Path
 import CabalScan.Rules
 import System.FilePath (dropExtension)
+
+#if __GLASGOW_HASKELL__ == 810
+
+import qualified Cabal.Cabal_8_10 as Cabal
+
+#elif __GLASGOW_HASKELL__ == 900
+
+import qualified Cabal.Cabal_9_0 as Cabal
+
+#else
+
+import qualified Cabal.Cabal_9_2 as Cabal
+
+#endif
 
 generateRulesForCabalFile :: Path b File -> IO [RuleInfo]
 generateRulesForCabalFile cabalFilePath = do
@@ -196,18 +196,18 @@ generateRule cabalFilePath pkgId dataFiles bi someModules ctype attrName mainFil
           , extraLibraries = Cabal.extraLibs bi
           , tools = map toToolName $ Cabal.buildToolDepends bi
           }
-          , version = pkgVersion
-          , srcs = map pathToString $ someModulePaths ++ otherModulePaths
-          , hiddenModules
-          , dataAttr =
-              -- The library always includes data files, and the other
-              -- components must include them if they don't depend on the
-              -- library.
-              if ctype == LIB || pkgName `notElem` deps
-              then nonEmpty $ dataFiles
-              else Nothing
-          , mainFile = mainFile
-          , privateAttrs = privAttrs
+        , version = pkgVersion
+        , srcs = map pathToString $ someModulePaths ++ otherModulePaths
+        , hiddenModules
+        , dataAttr =
+            -- The library always includes data files, and the other
+            -- components must include them if they don't depend on the
+            -- library.
+            if ctype == LIB || pkgName `notElem` deps
+            then nonEmpty dataFiles
+            else Nothing
+        , mainFile = mainFile
+        , privateAttrs = privAttrs
         }
   where
     pathToString = Path.toFilePath
@@ -387,7 +387,7 @@ data UnresolvedCabalDependencies = UnresolvedCabalDependencies
 readCabalFile :: Path b File -> IO Cabal.PackageDescription
 readCabalFile cabalFilePath = do
   let cabalFile = Path.toFilePath cabalFilePath
-  genericPkg <- Cabal.readGenericPackageDescription Verbosity.normal cabalFile
+  genericPkg <- Cabal.readGenericPackageDescription Cabal.silent cabalFile
   let flags = mempty
       componentSpec = Cabal.ComponentRequestedSpec
         { Cabal.testsRequested = True

--- a/cabalscan/tests/CabalScan/RuleGeneratorSpec.hs
+++ b/cabalscan/tests/CabalScan/RuleGeneratorSpec.hs
@@ -4,57 +4,58 @@ module CabalScan.RuleGeneratorSpec where
 
 import Test.Hspec
 import CabalScan.RuleGenerator (findModulePaths)
-import qualified Path
-import qualified Path.IO as Path
+import qualified System.FilePath as Path
+import qualified System.Directory as Path
+import qualified System.IO.Temp as Temp
 
 spec_toLibraryTarget :: Spec
 spec_toLibraryTarget = do
   describe "RuleGenerator.findModulePaths" $ do
     it "should find modules in multiple directories" $ do
-      cwd <- Path.getCurrentDir
-      Path.withTempDir cwd "findModulePaths" $ \dir -> do
-        aRel <- Path.parseRelDir "a"
-        Path.createDir (dir Path.</> aRel)
-        bRel <- Path.parseRelDir "b"
-        Path.createDir (dir Path.</> bRel)
-        modRel <- Path.parseRelFile "A/B/C"
-        foundModulePath <- (bRel Path.</>) <$> Path.addExtension ".hs" modRel
+      cwd <- Path.getCurrentDirectory
+      Temp.withTempDirectory cwd "findModulePaths" $ \dir -> do
+        let aRel = "a"
+        Path.createDirectory (dir Path.</> aRel)
+        let bRel = "b"
+        Path.createDirectory (dir Path.</> bRel)
+        let modRel = "A/B/C"
+        let foundModulePath = bRel Path.</> modRel Path.<.> ".hs"
         let expected = [foundModulePath]
-        Path.ensureDir $ Path.parent (dir Path.</> bRel Path.</> modRel)
+        Path.createDirectoryIfMissing True $ Path.takeDirectory (dir Path.</> bRel Path.</> modRel)
 
-        writeFile (Path.toFilePath (dir Path.</> foundModulePath) ) ""
+        writeFile (dir Path.</> foundModulePath) ""
         findModulePaths dir [aRel, bRel] modRel
           `shouldMatchListIO` expected
 
     it "should find hs-boot files" $ do
-      cwd <- Path.getCurrentDir
-      Path.withTempDir cwd "findModulePaths" $ \dir -> do
-        bRel <- Path.parseRelDir "b"
-        Path.createDir (dir Path.</> bRel)
-        modRel <- Path.parseRelFile "A/B/C"
-        foundModulePath <- (bRel Path.</>) <$> Path.addExtension ".hs" modRel
-        foundBootPath <- (bRel Path.</>) <$> Path.addExtension ".hs-boot" modRel
+      cwd <- Path.getCurrentDirectory
+      Temp.withTempDirectory cwd "findModulePaths" $ \dir -> do
+        let bRel = "b"
+        Path.createDirectory (dir Path.</> bRel)
+        let modRel = "A/B/C"
+        let foundModulePath = bRel Path.</> modRel Path.<.> ".hs"
+        let foundBootPath = bRel Path.</> modRel Path.<.> ".hs-boot"
         let expected = [foundModulePath, foundBootPath]
-        Path.ensureDir $ Path.parent (dir Path.</> bRel Path.</> modRel)
+        Path.createDirectoryIfMissing True $ Path.takeDirectory (dir Path.</> bRel Path.</> modRel)
 
-        writeFile (Path.toFilePath (dir Path.</> foundModulePath) ) ""
-        writeFile (Path.toFilePath (dir Path.</> foundBootPath) ) ""
+        writeFile (dir Path.</> foundModulePath) ""
+        writeFile (dir Path.</> foundBootPath) ""
         findModulePaths dir [bRel] modRel
           `shouldMatchListIO` expected
 
     it "should find lhs-boot files" $ do
-      cwd <- Path.getCurrentDir
-      Path.withTempDir cwd "findModulePaths" $ \dir -> do
-        bRel <- Path.parseRelDir "b"
-        Path.createDir (dir Path.</> bRel)
-        modRel <- Path.parseRelFile "A/B/C"
-        foundModulePath <- (bRel Path.</>) <$> Path.addExtension ".lhs" modRel
-        foundBootPath <- (bRel Path.</>) <$> Path.addExtension ".lhs-boot" modRel
+      cwd <- Path.getCurrentDirectory
+      Temp.withTempDirectory cwd "findModulePaths" $ \dir -> do
+        let bRel = "b"
+        Path.createDirectory (dir Path.</> bRel)
+        let modRel = "A/B/C"
+        let foundModulePath = bRel Path.</> modRel Path.<.> ".lhs"
+        let foundBootPath = bRel Path.</> modRel Path.<.> ".lhs-boot"
         let expected = [foundModulePath, foundBootPath]
-        Path.ensureDir $ Path.parent (dir Path.</> bRel Path.</> modRel)
+        Path.createDirectoryIfMissing True $ Path.takeDirectory (dir Path.</> bRel Path.</> modRel)
 
-        writeFile (Path.toFilePath (dir Path.</> foundModulePath) ) ""
-        writeFile (Path.toFilePath (dir Path.</> foundBootPath) ) ""
+        writeFile (dir Path.</> foundModulePath) ""
+        writeFile (dir Path.</> foundBootPath) ""
         findModulePaths dir [bRel] modRel
           `shouldMatchListIO` expected
 

--- a/config_settings/setup.bzl
+++ b/config_settings/setup.bzl
@@ -1,0 +1,18 @@
+def _config_settings_impl(repository_ctx):
+    ghc_version = repository_ctx.os.environ.get("GHC_VERSION", default = "8.10.7")
+    repository_ctx.file(
+        "BUILD",
+        content = """exports_files(["info.bzl"])""",
+        executable = False,
+    )
+    repository_ctx.file(
+        "info.bzl",
+        content = 'ghc_version = "{}"'.format(ghc_version),
+        executable = False,
+    )
+
+config_settings = repository_rule(
+    implementation = _config_settings_impl,
+    attrs = {},
+    environ = ["GHC_VERSION"],
+)

--- a/defs.bzl
+++ b/defs.bzl
@@ -7,12 +7,12 @@ def _gazelle_cabal_dependencies_impl(repository_ctx):
 package(default_visibility = ["//visibility:public"])
 
 alias(name="json", actual="{json}")
-alias(name="path", actual="{path}")
-alias(name="path-io", actual="{path_io}")
+alias(name="filepath", actual="{filepath}")
+alias(name="directory", actual="{directory}")
         '''.format(
             json = repository_ctx.attr.json,
-            path = repository_ctx.attr.path,
-            path_io = repository_ctx.attr.path_io,
+            filepath = repository_ctx.attr.filepath,
+            directory = repository_ctx.attr.directory,
         ),
         executable = False,
     )
@@ -22,8 +22,8 @@ _gazelle_cabal_dependencies = repository_rule(
     local = True,
     attrs = {
         "json": attr.label(default = "@stackage//:json"),
-        "path": attr.label(default = "@stackage//:path"),
-        "path_io": attr.label(default = "@stackage//:path-io"),
+        "filepath": attr.label(default = "@stackage//:filepath"),
+        "directory": attr.label(default = "@stackage//:directory"),
     },
 )
 
@@ -44,8 +44,8 @@ def gazelle_cabal_dependencies(**kargs):
       # Dependencies overriden
       gazelle_cabal_dependencies(
           json = "@someother//:some-other-json",
-          path = "@someother//:some-path",
-          path_io = "@someother//:another-path-io",
+          filepath = "@someother//:some-filepath",
+          directory = "@someother//:another-directory",
       )
 
       ```

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -53,53 +53,17 @@ gazelle_cabal_dependencies()
 
 stack_snapshot(
     name = "stackage",
-    components =
-        {
-            "tasty-discover": [
-                "lib",
-                "exe:tasty-discover",
-            ],
-        } if ghc_version == "8.10.7" else {
-            "tasty-discover": [
-                "lib",
-                "exe:tasty-discover",
-            ],
-            "attoparsec": [
-                "lib",
-                "lib:attoparsec-internal",
-            ],
-        },
-    components_dependencies =
-        None if ghc_version == "8.10.7" else {
-            "attoparsec": """{"lib:attoparsec": ["lib:attoparsec-internal"]}""",
-        },
     local_snapshot = "@io_tweag_gazelle_cabal//:snapshot-" + ghc_version + ".yaml",
     packages = [
         "Cabal",  #keep
-        "base",
-        "inspection-testing",
+        "directory",  #keep
+        "filepath",  #keep
         "json",  # keep
-        "mtl",
-        "path",  # keep
-        "path-io",  #keep
-        "tasty",
-        "tasty-discover",
-        "tasty-hunit",
-        "text",
-        "void",
     ],
     setup_deps = {
-        "transformers-compat": ["@stackage//:Cabal"],
-        "hspec-discover": ["@stackage//:Cabal"],
         "call-stack": ["@stackage//:Cabal"],
-        "HUnit": ["@stackage//:Cabal"],
-        "quickcheck": ["@stackage//:Cabal"],
-        "hspec-expectations": ["@stackage//:Cabal"],
-        "quickcheck-io": ["@stackage//:Cabal"],
-        "hspec-core": ["@stackage//:Cabal"],
-        "bifunctors": ["@stackage//:Cabal"],
-        "hspec": ["@stackage//:Cabal"],
         "tasty-discover": ["@stackage//:Cabal"],
+        "transformers-compat": ["@stackage//:Cabal"],
     },
 )
 

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -10,11 +10,12 @@ local_repository(
 ##########################
 # rules_haskell preamble
 ##########################
+
 http_archive(
     name = "rules_haskell",
-    sha256 = "851e16edc7c33b977649d66f2f587071dde178a6e5bcfeca5fe9ebbe81924334",
-    strip_prefix = "rules_haskell-0.14",
-    url = "https://github.com/tweag/rules_haskell/archive/refs/tags/v0.14.tar.gz",
+    sha256 = "a8e029b9ebf2e8fd79f99134acefd99310f9427951b5260ce4c3cae88da57f1e",
+    strip_prefix = "rules_haskell-97220908a5950cb56638b893a384bd92a19188e2",
+    urls = ["https://github.com/tweag/rules_haskell/archive/97220908a5950cb56638b893a384bd92a19188e2.zip"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -41,24 +42,72 @@ load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 # Haskell dependencies and toolchain
 ######################################
 
+load("@io_tweag_gazelle_cabal//:config_settings/setup.bzl", "config_settings")
+
+config_settings(name = "config_settings")
+
+load("@config_settings//:info.bzl", "ghc_version")
 load("@io_tweag_gazelle_cabal//:defs.bzl", "gazelle_cabal_dependencies")
 
 gazelle_cabal_dependencies()
 
 stack_snapshot(
     name = "stackage",
+    components =
+        {
+            "tasty-discover": [
+                "lib",
+                "exe:tasty-discover",
+            ],
+        } if ghc_version == "8.10.7" else {
+            "tasty-discover": [
+                "lib",
+                "exe:tasty-discover",
+            ],
+            "attoparsec": [
+                "lib",
+                "lib:attoparsec-internal",
+            ],
+        },
+    components_dependencies =
+        None if ghc_version == "8.10.7" else {
+            "attoparsec": """{"lib:attoparsec": ["lib:attoparsec-internal"]}""",
+        },
+    local_snapshot = "@io_tweag_gazelle_cabal//:snapshot-" + ghc_version + ".yaml",
     packages = [
+        "Cabal",  #keep
+        "base",
+        "inspection-testing",
         "json",  # keep
+        "mtl",
         "path",  # keep
         "path-io",  #keep
+        "tasty",
+        "tasty-discover",
+        "tasty-hunit",
+        "text",
+        "void",
     ],
-    snapshot = "lts-18.28",
+    setup_deps = {
+        "transformers-compat": ["@stackage//:Cabal"],
+        "hspec-discover": ["@stackage//:Cabal"],
+        "call-stack": ["@stackage//:Cabal"],
+        "HUnit": ["@stackage//:Cabal"],
+        "quickcheck": ["@stackage//:Cabal"],
+        "hspec-expectations": ["@stackage//:Cabal"],
+        "quickcheck-io": ["@stackage//:Cabal"],
+        "hspec-core": ["@stackage//:Cabal"],
+        "bifunctors": ["@stackage//:Cabal"],
+        "hspec": ["@stackage//:Cabal"],
+        "tasty-discover": ["@stackage//:Cabal"],
+    },
 )
 
 load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "haskell.compiler.ghc8107",
+    attribute_path =
+        "haskell.compiler.ghc" + ghc_version.replace(".", ""),
     ghcopts = [
         "-Werror",
         "-Wall",
@@ -67,7 +116,7 @@ haskell_register_ghc_nixpkgs(
         "-Wredundant-constraints",
     ],
     repositories = {"nixpkgs": "@nixpkgs"},
-    version = "8.10.7",
+    version = ghc_version,
 )
 
 ###############

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,1 +1,1 @@
-import (fetchTarball "https://github.com/nixos/nixpkgs/archive/9bc841fec1c0e8b9772afa29f934d2c7ce57da8e.tar.gz")
+import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.05.tar.gz")

--- a/snapshot-8.10.7.yaml
+++ b/snapshot-8.10.7.yaml
@@ -1,0 +1,1 @@
+resolver: lts-18.28

--- a/snapshot-9.0.2.yaml
+++ b/snapshot-9.0.2.yaml
@@ -1,0 +1,1 @@
+resolver: lts-19.12

--- a/snapshot-9.2.2.yaml
+++ b/snapshot-9.2.2.yaml
@@ -1,0 +1,7 @@
+resolver: nightly-2022-06-06
+
+packages:
+- git: https://github.com/tweag/cabal
+  commit: 42f04c3f639f10dc3c7981a0c663bfe08ad833cb
+  subdirs:
+  - Cabal

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -50,9 +50,9 @@ load("@config_settings//:info.bzl", "ghc_version")
 load("@io_tweag_gazelle_cabal//:defs.bzl", "gazelle_cabal_dependencies")
 
 gazelle_cabal_dependencies(
+    directory = "@stackage-b//:directory",
+    filepath = "@stackage-b//:filepath",
     json = "@stackage-b//:json",
-    path = "@stackage-b//:path",
-    path_io = "@stackage-b//:path-io",
 )
 
 stack_snapshot(
@@ -65,46 +65,16 @@ stack_snapshot(
 
 stack_snapshot(
     name = "stackage-b",
-    components =
-        {
-            "tasty-discover": [
-                "lib",
-                "exe:tasty-discover",
-            ],
-        } if ghc_version == "8.10.7" else {
-            "tasty-discover": [
-                "lib",
-                "exe:tasty-discover",
-            ],
-            "attoparsec": [
-                "lib",
-                "lib:attoparsec-internal",
-            ],
-        },
-    components_dependencies =
-        None if ghc_version == "8.10.7" else {
-            "attoparsec": """{"lib:attoparsec": ["lib:attoparsec-internal"]}""",
-        },
     local_snapshot = "@io_tweag_gazelle_cabal//:snapshot-" + ghc_version + ".yaml",
     packages = [
-        "inspection-testing",
+        "directory",  #keep
+        "filepath",  #keep
         "json",  # keep
-        "path",  # keep
-        "path-io",  #keep
-        "tasty-discover",
     ],
     setup_deps = {
-        "transformers-compat": ["@stackage//:Cabal"],
-        "hspec-discover": ["@stackage//:Cabal"],
         "call-stack": ["@stackage//:Cabal"],
-        "HUnit": ["@stackage//:Cabal"],
-        "quickcheck": ["@stackage//:Cabal"],
-        "hspec-expectations": ["@stackage//:Cabal"],
-        "quickcheck-io": ["@stackage//:Cabal"],
         "tasty-discover": ["@stackage//:Cabal"],
-        "hspec-core": ["@stackage//:Cabal"],
-        "bifunctors": ["@stackage//:Cabal"],
-        "hspec": ["@stackage//:Cabal"],
+        "transformers-compat": ["@stackage//:Cabal"],
     },
 )
 

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -13,9 +13,9 @@ local_repository(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "851e16edc7c33b977649d66f2f587071dde178a6e5bcfeca5fe9ebbe81924334",
-    strip_prefix = "rules_haskell-0.14",
-    url = "https://github.com/tweag/rules_haskell/archive/refs/tags/v0.14.tar.gz",
+    sha256 = "a8e029b9ebf2e8fd79f99134acefd99310f9427951b5260ce4c3cae88da57f1e",
+    strip_prefix = "rules_haskell-97220908a5950cb56638b893a384bd92a19188e2",
+    urls = ["https://github.com/tweag/rules_haskell/archive/97220908a5950cb56638b893a384bd92a19188e2.zip"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -42,6 +42,11 @@ load("@rules_haskell//haskell:cabal.bzl", "stack_snapshot")
 # Haskell dependencies and toolchain
 ######################################
 
+load("@io_tweag_gazelle_cabal//:config_settings/setup.bzl", "config_settings")
+
+config_settings(name = "config_settings")
+
+load("@config_settings//:info.bzl", "ghc_version")
 load("@io_tweag_gazelle_cabal//:defs.bzl", "gazelle_cabal_dependencies")
 
 gazelle_cabal_dependencies(
@@ -51,20 +56,63 @@ gazelle_cabal_dependencies(
 )
 
 stack_snapshot(
+    name = "stackage",
+    local_snapshot = "@io_tweag_gazelle_cabal//:snapshot-" + ghc_version + ".yaml",
+    packages = [
+        "Cabal",  #keep
+    ],
+)
+
+stack_snapshot(
     name = "stackage-b",
+    components =
+        {
+            "tasty-discover": [
+                "lib",
+                "exe:tasty-discover",
+            ],
+        } if ghc_version == "8.10.7" else {
+            "tasty-discover": [
+                "lib",
+                "exe:tasty-discover",
+            ],
+            "attoparsec": [
+                "lib",
+                "lib:attoparsec-internal",
+            ],
+        },
+    components_dependencies =
+        None if ghc_version == "8.10.7" else {
+            "attoparsec": """{"lib:attoparsec": ["lib:attoparsec-internal"]}""",
+        },
+    local_snapshot = "@io_tweag_gazelle_cabal//:snapshot-" + ghc_version + ".yaml",
     packages = [
         "inspection-testing",
         "json",  # keep
         "path",  # keep
         "path-io",  #keep
+        "tasty-discover",
     ],
-    snapshot = "lts-18.28",
+    setup_deps = {
+        "transformers-compat": ["@stackage//:Cabal"],
+        "hspec-discover": ["@stackage//:Cabal"],
+        "call-stack": ["@stackage//:Cabal"],
+        "HUnit": ["@stackage//:Cabal"],
+        "quickcheck": ["@stackage//:Cabal"],
+        "hspec-expectations": ["@stackage//:Cabal"],
+        "quickcheck-io": ["@stackage//:Cabal"],
+        "tasty-discover": ["@stackage//:Cabal"],
+        "hspec-core": ["@stackage//:Cabal"],
+        "bifunctors": ["@stackage//:Cabal"],
+        "hspec": ["@stackage//:Cabal"],
+    },
 )
 
 load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "haskell.compiler.ghc8107",
+    attribute_path =
+        "haskell.compiler.ghc" + ghc_version.replace(".", ""),
     ghcopts = [
         "-Werror",
         "-Wall",
@@ -73,7 +121,7 @@ haskell_register_ghc_nixpkgs(
         "-Wredundant-constraints",
     ],
     repositories = {"nixpkgs": "@nixpkgs"},
-    version = "8.10.7",
+    version = ghc_version,
 )
 
 ###############


### PR DESCRIPTION
The packages `path` and `path-io` depend of `aeson`, hence #40 did not achieve its goal to lighten the dependencies. Here is a more important change, to really suppress aeson and all its dependencies.