### PR TITLE
Support GHC 9.4.5

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,8 @@ common:ghc_8_10_7 --repo_env=GHC_VERSION=8.10.7
 
 common:ghc_9_0_2 --repo_env=GHC_VERSION=9.0.2
 
-common:ghc_9_2_2 --repo_env=GHC_VERSION=9.2.2
+common:ghc_9_2_7 --repo_env=GHC_VERSION=9.2.7
+
+common:ghc_9_4_5 --repo_env=GHC_VERSION=9.4.5
 
 try-import .bazelrc.local

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc-version: [ghc_8_10_7, ghc_9_0_2, ghc_9_2_2]
+        ghc-version: [ghc_8_10_7, ghc_9_0_2, ghc_9_2_7, ghc_9_4_5]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,9 +8,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "33b9b012172ae530ba1591be0832a77cfe063062be90311b94720e73264c09da",
-    strip_prefix = "rules_haskell-8140a709a2fce93dcdaca44a65bb98399b30798a",
-    urls = ["https://github.com/tweag/rules_haskell/archive/8140a709a2fce93dcdaca44a65bb98399b30798a.zip"],
+    sha256 = "441c45778bf469a36c7b9457c962579408ec47f9c5883c8001e9412d6c801f08",
+    strip_prefix = "rules_haskell-1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89",
+    urls = ["https://github.com/tweag/rules_haskell/archive/1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89.zip"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,9 +8,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "a8e029b9ebf2e8fd79f99134acefd99310f9427951b5260ce4c3cae88da57f1e",
-    strip_prefix = "rules_haskell-97220908a5950cb56638b893a384bd92a19188e2",
-    urls = ["https://github.com/tweag/rules_haskell/archive/97220908a5950cb56638b893a384bd92a19188e2.zip"],
+    sha256 = "33b9b012172ae530ba1591be0832a77cfe063062be90311b94720e73264c09da",
+    strip_prefix = "rules_haskell-8140a709a2fce93dcdaca44a65bb98399b30798a",
+    urls = ["https://github.com/tweag/rules_haskell/archive/8140a709a2fce93dcdaca44a65bb98399b30798a.zip"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -107,10 +107,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
+    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.39.1.zip",
     ],
 )
 

--- a/cabalscan/src/Cabal/Cabal_9_4.hs
+++ b/cabalscan/src/Cabal/Cabal_9_4.hs
@@ -1,0 +1,47 @@
+{-#LANGUAGE CPP #-}
+
+#if __GLASGOW_HASKELL__ == 904
+
+module Cabal.Cabal_9_4(module Cabal, depLibraries, hsSourceDirs)
+
+where
+
+import Distribution.Compiler as Cabal (CompilerFlavor(GHC), perCompilerFlavorToList, unknownCompilerInfo, CompilerId(CompilerId), AbiTag(NoAbiTag))
+import Distribution.ModuleName as Cabal (toFilePath, components)
+import Distribution.Package as Cabal ()
+import Distribution.PackageDescription as Cabal (allLibraries, executables, testSuites, benchmarks, package, dataFiles, Library, libName, exposedModules, libBuildInfo, Executable, exeName, buildInfo, modulePath, TestSuite, testName, testBuildInfo, TestSuiteInterface(TestSuiteExeV10), testInterface, Benchmark, benchmarkName, benchmarkBuildInfo, BenchmarkInterface(BenchmarkExeV10), benchmarkInterface, BuildInfo, buildable, otherModules, extraLibs)
+import Distribution.PackageDescription.Configuration as Cabal (finalizePD)
+import Distribution.Simple.PackageDescription as Cabal (readGenericPackageDescription)
+import Distribution.Types.BuildInfo as Cabal (buildToolDepends, targetBuildDepends, defaultExtensions, cppOptions, ldOptions, options)
+import Distribution.Types.ComponentRequestedSpec as Cabal (ComponentRequestedSpec(ComponentRequestedSpec), testsRequested, benchmarksRequested)
+import Distribution.Types.Dependency as Cabal (Dependency, depPkgName)
+import Distribution.Types.ExeDependency as Cabal (ExeDependency(ExeDependency))
+import Distribution.Types.Library as Cabal (libVisibility)
+import Distribution.Types.LibraryName as Cabal (LibraryName(LSubLibName))
+import Distribution.Types.LibraryVisibility as Cabal (LibraryVisibility(LibraryVisibilityPrivate))
+import Distribution.Types.PackageDescription as Cabal (PackageDescription)
+import Distribution.Types.PackageId as Cabal (PackageIdentifier, pkgName, pkgVersion)
+import Distribution.Types.PackageName as Cabal (PackageName, unPackageName)
+import Distribution.Types.UnqualComponentName as Cabal (unUnqualComponentName)
+import Distribution.Types.Version as Cabal (mkVersion)
+import Distribution.Pretty as Cabal (prettyShow)
+import Distribution.System as Cabal (Platform(Platform), buildArch, buildOS)
+import Distribution.Verbosity as Cabal (silent)
+
+import qualified Distribution.Types.Dependency as C (depLibraries)
+import qualified Distribution.Compat.NonEmptySet as C (toSet)
+import Data.Set.Internal (Set)
+import qualified Distribution.PackageDescription as C (hsSourceDirs)
+import qualified Distribution.Utils.Path as C (getSymbolicPath)
+
+depLibraries :: Cabal.Dependency -> Set Cabal.LibraryName
+depLibraries = C.toSet . C.depLibraries
+
+hsSourceDirs :: Cabal.BuildInfo -> [FilePath]
+hsSourceDirs = map C.getSymbolicPath . C.hsSourceDirs
+
+#else
+
+module Cabal.Cabal_9_4 where
+
+#endif

--- a/cabalscan/src/CabalScan/RuleGenerator.hs
+++ b/cabalscan/src/CabalScan/RuleGenerator.hs
@@ -31,9 +31,13 @@ import qualified Cabal.Cabal_8_10 as Cabal
 
 import qualified Cabal.Cabal_9_0 as Cabal
 
-#else
+#elif __GLASGOW_HASKELL__ == 902
 
 import qualified Cabal.Cabal_9_2 as Cabal
+
+#else
+
+import qualified Cabal.Cabal_9_4 as Cabal
 
 #endif
 

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -13,9 +13,9 @@ local_repository(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "a8e029b9ebf2e8fd79f99134acefd99310f9427951b5260ce4c3cae88da57f1e",
-    strip_prefix = "rules_haskell-97220908a5950cb56638b893a384bd92a19188e2",
-    urls = ["https://github.com/tweag/rules_haskell/archive/97220908a5950cb56638b893a384bd92a19188e2.zip"],
+    sha256 = "33b9b012172ae530ba1591be0832a77cfe063062be90311b94720e73264c09da",
+    strip_prefix = "rules_haskell-8140a709a2fce93dcdaca44a65bb98399b30798a",
+    urls = ["https://github.com/tweag/rules_haskell/archive/8140a709a2fce93dcdaca44a65bb98399b30798a.zip"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -89,10 +89,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
+    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.39.1.zip",
     ],
 )
 

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -13,9 +13,9 @@ local_repository(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "33b9b012172ae530ba1591be0832a77cfe063062be90311b94720e73264c09da",
-    strip_prefix = "rules_haskell-8140a709a2fce93dcdaca44a65bb98399b30798a",
-    urls = ["https://github.com/tweag/rules_haskell/archive/8140a709a2fce93dcdaca44a65bb98399b30798a.zip"],
+    sha256 = "441c45778bf469a36c7b9457c962579408ec47f9c5883c8001e9412d6c801f08",
+    strip_prefix = "rules_haskell-1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89",
+    urls = ["https://github.com/tweag/rules_haskell/archive/1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89.zip"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,1 +1,1 @@
-import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.05.tar.gz")
+import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/tags/23.05.tar.gz")

--- a/snapshot-9.2.7.yaml
+++ b/snapshot-9.2.7.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-06-06
+resolver: lts-20.22
 
 packages:
 - git: https://github.com/tweag/cabal

--- a/snapshot-9.4.5.yaml
+++ b/snapshot-9.4.5.yaml
@@ -1,0 +1,7 @@
+resolver: lts-21.2
+
+packages:
+- git: https://github.com/tweag/cabal
+  commit: 42f04c3f639f10dc3c7981a0c663bfe08ad833cb
+  subdirs:
+  - Cabal

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -13,9 +13,9 @@ local_repository(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "a8e029b9ebf2e8fd79f99134acefd99310f9427951b5260ce4c3cae88da57f1e",
-    strip_prefix = "rules_haskell-97220908a5950cb56638b893a384bd92a19188e2",
-    urls = ["https://github.com/tweag/rules_haskell/archive/97220908a5950cb56638b893a384bd92a19188e2.zip"],
+    sha256 = "33b9b012172ae530ba1591be0832a77cfe063062be90311b94720e73264c09da",
+    strip_prefix = "rules_haskell-8140a709a2fce93dcdaca44a65bb98399b30798a",
+    urls = ["https://github.com/tweag/rules_haskell/archive/8140a709a2fce93dcdaca44a65bb98399b30798a.zip"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")
@@ -100,10 +100,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
+    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.39.1.zip",
     ],
 )
 

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -13,9 +13,9 @@ local_repository(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "33b9b012172ae530ba1591be0832a77cfe063062be90311b94720e73264c09da",
-    strip_prefix = "rules_haskell-8140a709a2fce93dcdaca44a65bb98399b30798a",
-    urls = ["https://github.com/tweag/rules_haskell/archive/8140a709a2fce93dcdaca44a65bb98399b30798a.zip"],
+    sha256 = "441c45778bf469a36c7b9457c962579408ec47f9c5883c8001e9412d6c801f08",
+    strip_prefix = "rules_haskell-1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89",
+    urls = ["https://github.com/tweag/rules_haskell/archive/1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89.zip"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")


### PR DESCRIPTION
Adds support for GHC 9.4.5.
Updates the nixpkgs revision to provide GHC 9.4.5.
Update the 9.2 tests from 9.2.2 to 9.2.7 to match the corresponding GHC version provided by nixpkgs.
Update rules_haskell, rules_nixpkgs (implicitly through rules_haskell), and rules_go to support the more recent nixpkgs revison.
