### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,5 +1,10 @@
 name: Continuous integration
-on: [push, pull_request]
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+  workflow_dispatch: # allows manual triggering
 env:
   # Bump this number to invalidate the GH actions cache
   cache-version: 0
@@ -27,12 +32,18 @@ jobs:
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
+          if [ -z "$BUILDBUDDY_API_KEY" ]; then
+              cache_setting='--noremote_upload_local_results'
+          else
+              cache_setting="--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+          fi
+
           cat >.bazelrc.local <<EOF
           build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
           build --bes_results_url=https://app.buildbuddy.io/invocation/
           build --bes_backend=grpcs://cloud.buildbuddy.io
           build --remote_cache=grpcs://cloud.buildbuddy.io
-          build --remote_header=x-buildbuddy-api-key="$BUILDBUDDY_API_KEY"
+          build $cache_setting
           build --remote_timeout=600
           build --keep_backend_build_event_connections_alive=false
           build --repository_cache=~/repo-cache/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,25 @@
+
+pull_request_rules:
+  - name: automatic merge
+    conditions:
+      - "label=merge-queue"
+      - "base=main"
+    actions:
+      queue:
+        name: default
+        method: merge
+
+  - name: delete head branch after merge
+    conditions:
+      - merged
+      - closed
+    actions:
+      delete_head_branch: {}
+
+  - name: remove from merge-queue after merge
+    conditions:
+      - merged
+    actions:
+      label:
+        remove:
+          - "merge-queue"


### PR DESCRIPTION
_This change has been made by @avdv from Mergify config editor._

This sets up mergify, which is not yet active on this repository.

It allows automatic merging for PRs to the `main` branch when adding the `merge-queue` label.

According to the documentation (see https://docs.mergify.com/conditions/#about-branch-protection) it will also automatically add conditions for Github induced branch protection rules, e.g. require review and require status checks to pass.