### PR TITLE
Update Bazel dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -132,10 +132,10 @@ go_rules_dependencies()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
+    sha256 = "d3fa66a39028e97d76f9e2db8f1b0c11c099e8e01bf363a923074784e451f809",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -108,10 +108,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
+    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.39.1.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,9 +8,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "441c45778bf469a36c7b9457c962579408ec47f9c5883c8001e9412d6c801f08",
-    strip_prefix = "rules_haskell-1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89",
-    urls = ["https://github.com/tweag/rules_haskell/archive/1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89.zip"],
+    sha256 = "1485a90366039fe8ea5051732dc50827d8c1e9bb6feb2c8bb1ad1fed5344cff0",
+    strip_prefix = "rules_haskell-155ba21c7d315cc421ee3f17a1c09b758cc7279d",
+    urls = ["https://github.com/tweag/rules_haskell/archive/155ba21c7d315cc421ee3f17a1c09b758cc7279d.tar.gz"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -157,7 +157,9 @@ gazelle_dependencies()
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    sha256 = "5b7fe9aa131ab64a51de4da3668005cf58418c967438ce129aad24fd3e6dfaa9",
-    strip_prefix = "buildtools-4890966c38b910fd5bd1ad78a3dd88538d09854f",
-    url = "https://github.com/bazelbuild/buildtools/archive/4890966c38b910fd5bd1ad78a3dd88538d09854f.zip",
+    sha256 = "42968f9134ba2c75c03bb271bd7bb062afb7da449f9b913c96e5be4ce890030a",
+    strip_prefix = "buildtools-6.3.3",
+    urls = [
+        "https://github.com/bazelbuild/buildtools/archive/refs/tags/v6.3.3.tar.gz",
+    ],
 )

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -13,9 +13,9 @@ local_repository(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "441c45778bf469a36c7b9457c962579408ec47f9c5883c8001e9412d6c801f08",
-    strip_prefix = "rules_haskell-1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89",
-    urls = ["https://github.com/tweag/rules_haskell/archive/1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89.zip"],
+    sha256 = "1485a90366039fe8ea5051732dc50827d8c1e9bb6feb2c8bb1ad1fed5344cff0",
+    strip_prefix = "rules_haskell-155ba21c7d315cc421ee3f17a1c09b758cc7279d",
+    urls = ["https://github.com/tweag/rules_haskell/archive/155ba21c7d315cc421ee3f17a1c09b758cc7279d.tar.gz"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -89,10 +89,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
+    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.39.1.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
     ],
 )
 

--- a/example/WORKSPACE
+++ b/example/WORKSPACE
@@ -113,10 +113,10 @@ go_rules_dependencies()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
+    sha256 = "d3fa66a39028e97d76f9e2db8f1b0c11c099e8e01bf363a923074784e451f809",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz",
     ],
 )
 

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,7 @@ mkShell {
   # See: https://github.com/bazelbuild/bazel/issues/4231
   BAZEL_USE_CPP_ONLY_TOOLCHAIN=1;
   buildInputs = [
-    bazel_5
+    bazel_6
     binutils
     cacert
     nix

--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,7 @@ mkShell {
     git
     openjdk11
     python3
+    stack
     # convenience dependencies
     less
   ];

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -13,9 +13,9 @@ local_repository(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "441c45778bf469a36c7b9457c962579408ec47f9c5883c8001e9412d6c801f08",
-    strip_prefix = "rules_haskell-1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89",
-    urls = ["https://github.com/tweag/rules_haskell/archive/1bd3c46ee88c8c4ff729959de56cc2ca9bf1cf89.zip"],
+    sha256 = "1485a90366039fe8ea5051732dc50827d8c1e9bb6feb2c8bb1ad1fed5344cff0",
+    strip_prefix = "rules_haskell-155ba21c7d315cc421ee3f17a1c09b758cc7279d",
+    urls = ["https://github.com/tweag/rules_haskell/archive/155ba21c7d315cc421ee3f17a1c09b758cc7279d.tar.gz"],
 )
 
 load("@rules_haskell//haskell:repositories.bzl", "rules_haskell_dependencies")

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -100,10 +100,10 @@ haskell_register_ghc_nixpkgs(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
+    sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.39.1.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
     ],
 )
 

--- a/tests/alternative-deps/WORKSPACE
+++ b/tests/alternative-deps/WORKSPACE
@@ -124,10 +124,10 @@ go_rules_dependencies()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
+    sha256 = "d3fa66a39028e97d76f9e2db8f1b0c11c099e8e01bf363a923074784e451f809",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Update all Bazel rule dependencies to the latest releases, or latest HEAD in case of rules_haskell.

- Update rules_haskell to latest HEAD
- Update rules_go to the latest release 0.41.0
- Update Gazelle to the latest release 0.33.0
- Update buildtools to latest release 6.3.3

Update Bazel to version 6.2.0

Also adds stack to the Nix shell.

- Add stack to the Nix shell
