### PR TITLE
chore: schedule daily CI run and add status badge tied to daily CI run

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches: main
   workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '1 11 * * *'
 env:
   # Bump this number to invalidate the GH actions cache
   cache-version: 0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gazelle\_cabal
 
-![Build status](https://github.com/tweag/gazelle_cabal/actions/workflows/workflow.yaml/badge.svg?branch=main)
+[![Continuous Integration](https://github.com/tweag/gazelle_cabal/actions/workflows/workflow.yaml/badge.svg?event=schedule)](https://github.com/tweag/gazelle_cabal/actions/workflows/workflow.yaml)
 
 
 This is a [gazelle][gazelle] extension that generates and


### PR DESCRIPTION
Related to tweag/scalable-builds-group#108.